### PR TITLE
Fix azure cli VMSSPreview feature register command

### DIFF
--- a/doc/source/microsoft/step-zero-azure-autoscale.rst
+++ b/doc/source/microsoft/step-zero-azure-autoscale.rst
@@ -76,7 +76,7 @@ If you prefer to use the Azure portal see the `Azure Kubernetes Service quicksta
 
    .. code-block:: bash
 
-     az feature --name VMSSPreview --namespace Microsoft.ContainerService
+     az feature register --name VMSSPreview --namespace Microsoft.ContainerService
 
    A VMSS is a `Virtual Machine Scale Set <https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/overview>`_, that is to say an autoscalable set of virtual machines.
 


### PR DESCRIPTION
The command was incorrect and produced an error:
`
az feature --name VMSSPreview --namespace Microsoft.ContainerService
az feature: 'VMSSPreview' is not in the 'az feature' command group. See 'az feature --help'.
`
The correct command should be 

`
az feature register --name VMSSPreview --namespace Microsoft.ContainerService
`
see MS docs: https://docs.microsoft.com/en-us/azure/aks/cluster-autoscaler